### PR TITLE
utf64: use tsdown instead of tsc to build for distribution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       markdown-toc:
         specifier: ^1.2.0
         version: 1.2.0
+      tsdown:
+        specifier: ^0.22.4
+        version: 0.22.4(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/utf64/js/package.json
+++ b/utf64/js/package.json
@@ -14,7 +14,8 @@
     "url": "https://github.com/more-please/more-stuff.git",
     "directory": "utf64/js"
   },
-  "main": "build/utf64.js",
+  "main": "build/utf64.mjs",
+  "types": "build/utf64.d.mts",
   "type": "module",
   "bin": {
     "utf64": "utf64.sh"
@@ -24,15 +25,30 @@
     "LICENSE",
     "build/*"
   ],
+  "tsdown": {
+    "entry": [
+      "utf64.ts",
+      "utf64.tool.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "outDir": "build",
+    "target": "es2015",
+    "splitting": false,
+    "dts": true,
+    "clean": true
+  },
   "scripts": {
     "format": "biome check --write --unsafe . && markdown-toc -i ../README.md",
     "test": "vitest run",
-    "prepare": "tsc && cp -f ../README.md ../LICENSE ."
+    "prepare": "tsdown && cp -f ../README.md ../LICENSE ."
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.0",
     "@types/node": "^26.1.1",
     "markdown-toc": "^1.2.0",
+    "tsdown": "^0.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   }

--- a/utf64/js/tsconfig.json
+++ b/utf64/js/tsconfig.json
@@ -9,10 +9,9 @@
     "lib": ["es2015"],
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
-    "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "outDir": "build"
-  },
-  "files": ["utf64.ts", "utf64.tool.ts"]
+    "noEmit": true,
+    "types": ["node"]
+  }
 }

--- a/utf64/js/utf64.sh
+++ b/utf64/js/utf64.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-# Simple launcher for utf64.tool.js (as TSC doesn't make it executable)
+# Simple launcher for utf64.tool.mjs (as tsdown doesn't make it executable)
 
-exec node $(dirname $0)/build/utf64.tool.js "$@"
+exec node $(dirname $0)/build/utf64.tool.mjs "$@"


### PR DESCRIPTION
## Summary

Migrates the `utf64` JS package's distribution build from **TSC** to **tsdown**, matching the convention already used by the other packages in this monorepo (`build-info`, `runfig`, `remark-bundle`, `rollup-plugin-build-info`, `static-file-bundle`).

## Changes

- **`utf64/js/package.json`**
  - Added a `tsdown` config block (entries `utf64.ts` + `utf64.tool.ts`, `esm` format, `dts`, `target: es2015`, `outDir: build`, `clean`).
  - Changed the `prepare` script from `tsc` to `tsdown`, keeping the step that copies `README.md`/`LICENSE` from the parent directory.
  - tsdown emits ESM as `.mjs`/`.d.mts`, so `main` now points at `build/utf64.mjs` and an explicit `types: build/utf64.d.mts` was added.
  - Added `tsdown` to `devDependencies`.
- **`utf64/js/utf64.sh`** — launcher now runs `build/utf64.tool.mjs`.
- **`utf64/js/tsconfig.json`** — converted to a `noEmit` type-check-only config (dropped `outDir`/`declaration`/`files`), since tsdown now owns the build; `tsc` remains available for type-checking.
- **`pnpm-lock.yaml`** — records the new `tsdown` devDependency.

## Verification

- `tsdown` build produces `build/utf64.mjs`, `build/utf64.tool.mjs`, `build/utf64.d.mts`, `build/utf64.tool.d.mts`.
- `tsc` type-checks cleanly (no emit).
- All 26 `vitest` tests pass.
- CLI verified end-to-end via `utf64.sh`: encode/decode round-trip, `-v` (reads version from `../package.json`), and stdin input.
- `biome check` passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxKT65hbdBMD5Vvh1QZBG5)_