### PR TITLE
Fix broken "types" entries across the three build-info packages

### DIFF
--- a/build-info/build-info.ts
+++ b/build-info/build-info.ts
@@ -4,10 +4,10 @@ function run(command: string): string {
   return execSync(command, { encoding: "utf-8" }).trim();
 }
 
-export const branch =
+export const branch: string =
   process.env.GITHUB_REF_NAME ?? run("git rev-parse --abbrev-ref HEAD");
 
-export const commit =
+export const commit: string =
   process.env.GITHUB_SHA ?? run('git show --format="%H" -s HEAD');
 
-export const timestamp = new Date();
+export const timestamp: Date = new Date();

--- a/build-info/package.json
+++ b/build-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@moreplease/build-info",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "import { commit, timestamp } from \"@moreplease/build-info\"",
   "tsdown": {
     "entry": [
@@ -26,7 +26,7 @@
     "build/*"
   ],
   "main": "build/build-info.mjs",
-  "types": "build/index.d.ts",
+  "types": "build/build-info.d.mts",
   "devDependencies": {
     "@types/node": "^26.2.0",
     "tsdown": "^0.22.14",

--- a/esbuild-plugin-build-info/build/index.d.ts
+++ b/esbuild-plugin-build-info/build/index.d.ts
@@ -1,5 +1,14 @@
-export { BuildInfo } from "./build-info";
-
+/// <reference path="build-info.d.ts" />
 import type { Plugin } from "esbuild";
 
-export default function plugin(): Plugin;
+export interface BuildInfo {
+  timestamp: Date;
+  branch: string;
+  commit: string;
+}
+
+export function branch(): Promise<BuildInfo["branch"]>;
+export function commit(): Promise<BuildInfo["commit"]>;
+export function buildInfo(): Promise<BuildInfo>;
+
+export default function buildInfoPlugin(): Plugin;

--- a/esbuild-plugin-build-info/package.json
+++ b/esbuild-plugin-build-info/package.json
@@ -5,7 +5,7 @@
     "esbuild",
     "esbuild-plugin"
   ],
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "import { commit, timestamp } from \"build-info\"",
   "scripts": {
     "test": "tsc",
@@ -24,6 +24,6 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "esbuild": "^0.20.0"
+    "esbuild": ">=0.20.0"
   }
 }

--- a/rollup-plugin-build-info/build/index.d.ts
+++ b/rollup-plugin-build-info/build/index.d.ts
@@ -1,2 +1,2 @@
 /// <reference path="build-info.d.ts" />
-export { BuildInfo, branch, buildInfo, commit, default } from "./rollup-plugin-build-info.d.mts";
+export { BuildInfo, branch, buildInfo, commit, default } from "./rollup-plugin-build-info.mjs";

--- a/rollup-plugin-build-info/package.json
+++ b/rollup-plugin-build-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moreplease/rollup-plugin-build-info",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "keywords": [
     "rollup",


### PR DESCRIPTION
All three build-info packages ship a `"types"` entry that fails for consumers. Each one is broken differently; none of them can be fixed by republishing alone.

Verified empirically throughout: packing each tarball, installing it into a scratch project, and typechecking real imports under both `moduleResolution: "bundler"` and `"nodenext"`.

## 1. `@moreplease/build-info` — `"types"` points at a file that doesn't exist

`"types"` was `build/index.d.ts`, but tsdown builds the `build-info.ts` entry into `build/build-info.mjs` + `build/build-info.d.mts`. The published 0.0.1 tarball contains exactly:

```
package/build/build-info.mjs
package/build/build-info.d.mts   <- the real declarations
```

So consumers get no types and have to work around it:

```ts
// The published @moreplease/build-info package's "types" field points at a
// file it doesn't ship (build/index.d.ts vs the actual build-info.d.mts),
// so declare the module locally.
declare module "@moreplease/build-info" { ... }
```

The stale path looks copied from the two plugin packages, where `build/index.d.ts` is a hand-written, git-tracked type entry (which is also why they set `"clean": false`). This package has no such file.

**Fixed:** `"types"` → `build/build-info.d.mts`, pairing with the already-correct `"main"`.

Also annotated the exported constants explicitly. The published `build-info.d.mts` declares `branch` and `commit` as `any` because the dts pass resolved without node types; annotating makes the emitted declarations deterministic regardless of publish environment, and matches what the workaround above assumed (`string`).

## 2. `@moreplease/esbuild-plugin-build-info` — declarations don't compile, and are incomplete

```ts
export { BuildInfo } from "./build-info";
```

`build-info.d.ts` is the ambient declaration for the virtual `"build-info"` module — a global script, not a module. So this errors for every consumer: TS2306 (`not a module`) under bundler, TS2834 (needs a file extension) under nodenext.

Because that file was *imported* rather than *referenced*, its `declare module` never entered the program either. Consumers importing the module the plugin injects got:

```
error TS2307: Cannot find module 'build-info' or its corresponding type declarations.
```

The declarations were also missing `branch`, `commit` and `buildInfo`, which the plugin has always exported at runtime — importing any of them was a TS2724/TS2614 error.

**Fixed:** replaced with a triple-slash reference directive plus the full export surface, mirroring `esbuild-plugin-build-info.ts` and matching what the rollup plugin already exposes:

```ts
/// <reference path="build-info.d.ts" />
import type { Plugin } from "esbuild";

export interface BuildInfo {
  timestamp: Date;
  branch: string;
  commit: string;
}

export function branch(): Promise<BuildInfo["branch"]>;
export function commit(): Promise<BuildInfo["commit"]>;
export function buildInfo(): Promise<BuildInfo>;

export default function buildInfoPlugin(): Plugin;
```

### Bonus: the esbuild peer range excludes every current esbuild

```json
"peerDependencies": { "esbuild": "^0.20.0" }
```

esbuild is 0.x, so a caret pins the minor — `^0.20.0` means `>=0.20.0 <0.21.0`. That excludes everything from 0.21 up, including the `^0.28.2` this package develops against. Installing the plugin next to a current esbuild fails outright:

```
npm error Could not resolve dependency:
npm error peer esbuild@"^0.20.0" from @moreplease/esbuild-plugin-build-info@0.0.3
```

**Fixed:** widened to `>=0.20.0`. The install now resolves without `--legacy-peer-deps`.

## 3. `@moreplease/rollup-plugin-build-info` — declaration entry imports a declaration file

```ts
export { ... } from "./rollup-plugin-build-info.d.mts";
```

Importing a `.d.mts` directly is TS2846 (`A declaration file cannot be imported without 'import type'`), under both resolution modes. The specifier has to name the implementation.

**Fixed:** point it at `./rollup-plugin-build-info.mjs` and let TypeScript find the sibling `.d.mts`.

## Verification

Consumer typecheck matrix, against packed tarballs — default export, every named export, and the injected virtual module:

| package | bundler | nodenext |
|---|---|---|
| esbuild-plugin-build-info | pass | pass |
| rollup-plugin-build-info | pass | pass |
| build-info | pass | pass |

All four plugin combinations failed before this change. `pnpm test` (`tsc`) passes in all three packages.

Worth noting the pattern behind all three bugs: `pnpm test` is `tsc` over each package's *own* sources, so it never typechecks the `build/*.d.ts` files consumers actually receive. A small smoke-test consumer package in CI would have caught every one of these. Happy to add one as a follow-up if that seems worthwhile.

## Versions

Bumped `build-info` 0.0.1 → 0.0.2, `esbuild-plugin-build-info` 0.0.3 → 0.0.4, `rollup-plugin-build-info` 0.0.13 → 0.0.14, since these fixes only reach consumers via a republish.

## Notes, not addressed here

- The `build-info` README documents a default export and a `BuildInfo` type (`import buildInfo from "build-info"`), which the plugins' virtual modules provide but the runtime placeholder does not — it only has the three named exports. That's a public-API change rather than a packaging fix.
- `rollup-plugin-build-info/build/rollup-plugin-build-info.{mjs,d.mts}` are git-tracked even though `.gitignore` lists `build` and tsdown regenerates them on `prepare`. Only the two hand-written `.d.ts` files need tracking. I checked and they're not currently stale, so this is cosmetic — left alone to keep the diff focused.